### PR TITLE
GitHub actions setup

### DIFF
--- a/.github/workflows/wasm-build.yml
+++ b/.github/workflows/wasm-build.yml
@@ -1,0 +1,21 @@
+name: Publish Package to npmjs
+
+# Standard setup from https://docs.github.com/en/actions/publishing-packages/publishing-nodejs-packages
+
+on:
+  release:
+    types: [created]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      # Setup .npmrc file to publish to npm
+      - uses: actions/setup-node@v3
+        with:
+          node-version: '16.x'
+          registry-url: 'https://registry.npmjs.org'
+      - run: npm ci
+      - run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/wasm-build.yml
+++ b/.github/workflows/wasm-build.yml
@@ -1,10 +1,11 @@
 name: Publish Package to npmjs
 
-# Standard setup from https://docs.github.com/en/actions/publishing-packages/publishing-nodejs-packages
-
 on:
-  release:
-    types: [created]
+  push:
+    branches:
+      - main
+    paths:
+      - 'wasm/**'
 
 jobs:
   build:

--- a/.github/workflows/wasm-build.yml
+++ b/.github/workflows/wasm-build.yml
@@ -5,9 +5,13 @@ name: Publish Package to npmjs
 on:
   release:
     types: [created]
+
 jobs:
   build:
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./wasm
     steps:
       - uses: actions/checkout@v3
       # Setup .npmrc file to publish to npm


### PR DESCRIPTION
## Purpose of this PR

Setup github action to publish npm package on the registry (only for the `wasm` directory).

This will build and publish the [@volograms/web_vol_lib](https://www.npmjs.com/package/@volograms/web_vol_lib) package into the npm public registry, on every new push to `main` with changes on the `./wasm` directory.

## Changes made in this PR

Create a new workflow file for the npm publish operation

## Testing Summary
First we need to get the Action into the `main` branch to be able to test it (also to set up the manual jobs, not just the automatic builds)

## Risk Introduced and any Breaking Changes
Publishing unwanted changes if anyone works directly into `main` (which should be avoided at all).

## Pre-Merge Checklist

None, we should merge this so we can test it as soon as possible
