### PR TITLE
Fix npm ci

### DIFF
--- a/.github/workflows/wasm-build-ci.yml
+++ b/.github/workflows/wasm-build-ci.yml
@@ -1,0 +1,25 @@
+name: (dry run) Publish Package to npmjs
+
+on:
+  pull_request:
+    branches: [ main ]
+    paths:
+      - 'wasm/**'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./wasm
+    steps:
+      - uses: actions/checkout@v3
+      # Setup .npmrc file to publish to npm
+      - uses: actions/setup-node@v3
+        with:
+          node-version: '16.x'
+          registry-url: 'https://registry.npmjs.org'
+      - run: npm ci
+      - run: npm publish --dry-run
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/wasm/package-lock.json
+++ b/wasm/package-lock.json
@@ -1,0 +1,13 @@
+{
+  "name": "@volograms/web_vol_lib",
+  "version": "1.0.6",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@volograms/web_vol_lib",
+      "version": "1.0.6",
+      "license": "MIT"
+    }
+  }
+}

--- a/wasm/package.json
+++ b/wasm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@volograms/web_vol_lib",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "description": "This is an experimental repo to try using WebASM to convert one of our native libraries to web assembly, and read volograms with it",
   "main": "vol_player.mjs",
   "scripts": {


### PR DESCRIPTION
## Purpose of this PR

Fix missing elements for the npm publish automatic builds.

I didn't set up a manual job since that requires an update of the package version... For that it is just better to get a new PR and go through the whole review/ci/merge cycle

## Changes made in this PR

* Adding package-lock.json (fixes `npm ci` error)
* Increasing package version (`1.0.5` was already published)
* Create a CI job for open PRs against `main` to test if the npm publish job will succeed (dry run)

## Testing Summary

None, we need to open and merge this PR to actually test the changes 😛 

## Risk Introduced and any Breaking Changes

Only affect the publishing of the package (which is not working yet)

## Pre-Merge Checklist

* Check that the status checks did run correctly, then merge and check again in the Actions tab to see if the npm publish job actually succeeded
* Once the npm publish job succeeds, check https://www.npmjs.com/package/@volograms/web_vol_lib to see if version `1.0.6` was actually published